### PR TITLE
Fix sticky audio prompt

### DIFF
--- a/chatterbox_node.py
+++ b/chatterbox_node.py
@@ -48,6 +48,7 @@ class FL_ChatterboxTTSNode(AudioNodeBase):
     """
     _tts_model = None
     _tts_device = None
+    _tts_conds = None
     
     @classmethod
     def INPUT_TYPES(cls):
@@ -146,6 +147,7 @@ class FL_ChatterboxTTSNode(AudioNodeBase):
             # Load the TTS model or reuse if loaded and device matches
             if FL_ChatterboxTTSNode._tts_model is not None and FL_ChatterboxTTSNode._tts_device == device:
                 tts_model = FL_ChatterboxTTSNode._tts_model
+                tts_model.conds = FL_ChatterboxTTSNode._tts_conds
                 message += f"\nReusing loaded TTS model on {device}..."
             else:
                 if FL_ChatterboxTTSNode._tts_model is not None:
@@ -161,6 +163,7 @@ class FL_ChatterboxTTSNode(AudioNodeBase):
                 message += f"\nLoading TTS model on {device}..."
                 pbar.update_absolute(10) # Indicate model loading started
                 tts_model = ChatterboxTTS.from_pretrained(device=device)
+                FL_ChatterboxTTSNode._tts_conds = tts_model.conds
                 pbar.update_absolute(50) # Indicate model loading finished
 
                 if keep_model_loaded:


### PR DESCRIPTION
If `keep_mode_loaded` is enabled and `audio_prompt` is used it sticks to the model even after disconnecting the `Load audio` node until the model is reloaded. I propose saving the original conds and setting them explicitly on model reuse, they're later either overridden if audio prompt is connected or left as is if it's not resulting in expected behavior.