### PR TITLE
Scope the torch.load map_location wrapper instead of replacing it globally

### DIFF
--- a/chatterbox_node.py
+++ b/chatterbox_node.py
@@ -1,4 +1,5 @@
 import os
+import contextlib
 import torch
 import torchaudio
 import numpy as np
@@ -156,7 +157,8 @@ def load_turbo_model(device: str) -> ChatterboxTurboTTS:
     ]
 
     download_chatterbox_models("ResembleAI/chatterbox-turbo", turbo_files, local_dir)
-    return ChatterboxTurboTTS.from_local(str(local_dir), device)
+    with default_map_location():
+        return ChatterboxTurboTTS.from_local(str(local_dir), device)
 
 
 def load_tts_model(device: str) -> ChatterboxTTS:
@@ -177,7 +179,8 @@ def load_tts_model(device: str) -> ChatterboxTTS:
     ]
 
     download_chatterbox_models("ResembleAI/chatterbox", tts_files, local_dir)
-    return ChatterboxTTS.from_local(str(local_dir), device)
+    with default_map_location():
+        return ChatterboxTTS.from_local(str(local_dir), device)
 
 
 def load_multilingual_model(device: str) -> ChatterboxMultilingualTTS:
@@ -199,7 +202,8 @@ def load_multilingual_model(device: str) -> ChatterboxMultilingualTTS:
     ]
 
     download_chatterbox_models("ResembleAI/chatterbox", mtl_files, local_dir)
-    return ChatterboxMultilingualTTS.from_local(str(local_dir), device)
+    with default_map_location():
+        return ChatterboxMultilingualTTS.from_local(str(local_dir), device)
 
 
 def load_vc_model(device: str) -> ChatterboxVC:
@@ -218,9 +222,16 @@ def load_vc_model(device: str) -> ChatterboxVC:
     ]
 
     download_chatterbox_models("ResembleAI/chatterbox", vc_files, local_dir)
-    return ChatterboxVC.from_local(str(local_dir), device)
+    with default_map_location():
+        return ChatterboxVC.from_local(str(local_dir), device)
 
-# Monkey patch torch.load to use MPS or CPU if map_location is not specified
+# torch.load wrapper: default map_location to the active device (MPS / CUDA /
+# CPU) when the caller did not specify one. Installed via a context manager
+# rather than replacing torch.load process-wide — a global replacement
+# clobbers (and is clobbered by) other custom node packs that also wrap
+# torch.load, and forces map_location onto ComfyUI core and every other pack
+# that never opted in. Scoping keeps the device-defaulting only for this
+# pack's own Chatterbox model loads.
 original_torch_load = torch.load
 def patched_torch_load(*args, **kwargs):
     if 'map_location' not in kwargs:
@@ -234,7 +245,16 @@ def patched_torch_load(*args, **kwargs):
         kwargs['map_location'] = torch.device(device)
     return original_torch_load(*args, **kwargs)
 
-torch.load = patched_torch_load
+
+@contextlib.contextmanager
+def default_map_location():
+    """Temporarily install patched_torch_load for this pack's model loads."""
+    previous = torch.load
+    torch.load = patched_torch_load
+    try:
+        yield
+    finally:
+        torch.load = previous
 
 
 class AudioNodeBase:


### PR DESCRIPTION
## Problem

`chatterbox_node.py` installs `patched_torch_load` by replacing `torch.load` process-wide at import time:

```python
torch.load = patched_torch_load
```

Because this runs at import, it changes `torch.load` for the **entire Python process** — ComfyUI core and every other installed custom node pack, not just this one.

Two concrete issues in a shared environment (and especially on multi-tenant cloud runtimes where one ComfyUI process serves many users' jobs back to back):

1. **Cross-pack clobbering — last import wins.** Other custom node packs also wrap `torch.load`. Whichever pack imports last owns `torch.load`, so the process-wide behavior depends on custom-node import order, which is not deterministic.
2. **`map_location` forced onto callers that never opted in.** After import, every `torch.load` call anywhere in the process gets `map_location` injected when the caller omitted it — including ComfyUI core's own checkpoint loading and other packs that deliberately relied on the default device placement.

## Fix

Keep `patched_torch_load` exactly as-is, but install it only for the duration of this pack's own model loads, via a context manager:

```python
@contextlib.contextmanager
def default_map_location():
    previous = torch.load
    torch.load = patched_torch_load
    try:
        yield
    finally:
        torch.load = previous
```

All four `Chatterbox*.from_local(...)` call sites (`load_turbo_model`, `load_tts_model`, `load_multilingual_model`, `load_vc_model`) are wrapped with `with default_map_location():`, so the device-defaulting still applies to every Chatterbox model load. `torch.load` is restored immediately afterward and left untouched for ComfyUI core and other packs.

No change to how this pack loads models or to the MPS/CUDA/CPU defaulting behavior — only the blast radius of the patch is reduced from process-global to call-scoped.

## Testing

- `python -c "import ast; ast.parse(open('chatterbox_node.py').read())"` — syntax OK
- All four model-load functions still route through `patched_torch_load` via the context manager